### PR TITLE
Fix: only check for png support when requiring 

### DIFF
--- a/poke-line.el
+++ b/poke-line.el
@@ -38,6 +38,8 @@
 ;; in the modeline.
 
 ;;; Code:
+(unless (image-type-available-p 'png)
+  (user-error "PNG support not detected. poke-line requires png support"))
 
 (require 'cl-lib)
 (require 'poke-line-types)
@@ -141,10 +143,8 @@ Minimum of 3 units are required for poke-line."
 
 (defun poke-line-image-string (str image-path)
   "Return STR propertized to display the PNG at IMAGE-PATH."
-  (if (image-type-available-p 'png)
       (propertize str 'display
-                  (create-image image-path 'png nil :ascent 'center :mask 'heuristic))
-    str))
+                  (create-image image-path 'png nil :ascent 'center :mask 'heuristic)))
 
 (defun poke-line-create ()
   "Return the Pokemon indicator to be inserted into mode line."


### PR DESCRIPTION
Do we need to check for PNG support every time `poke-line-create` is invoked?
I've moved the check to the initialization of the minor mode. If it fails, a user error is thrown.
I don't have an Emacs on hand that doesn't have PNG support to test this, but I don't think this should hurt anything.